### PR TITLE
Fix emptyText description

### DIFF
--- a/ref/grid.html
+++ b/ref/grid.html
@@ -267,7 +267,7 @@
           <a id="empty-message" href="#empty-message" title="Empty Message" class="section">Empty Message</a>
         </h3>
         <p>If you want to display a message when the grid is empty. You can pass
-          an<code>emptyMessage</code> string to the <code>options</code> object
+          an<code>emptyText</code> property to the <code>options</code> object
           to the Grid's constructor.</p>
         <textarea class="code-snippet" data-mode="javascript">
           var grid = new Backgrid.Grid({


### PR DESCRIPTION
Clarify that "emptyText" should be property name instead of
"emptyMessage" in the description (code example is OK).
